### PR TITLE
fix: isolate plugin btop configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.btop.conf

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -77,6 +77,10 @@ Panel {
       + padLeft("Right click: menu", 17)
   }
 
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
   function resolveIconPath(path) {
     var value = String(path || "").trim()
     if (value.indexOf("~/") === 0)
@@ -92,17 +96,21 @@ Panel {
   }
 
   function launchBtop() {
+    if (!activity) return
     close()
     Quickshell.execDetached([
-      "omarchy-launch-or-focus-tui", "--app-id=" + btopAppId, "btop"
+      "omarchy-launch-or-focus-tui", "--app-id=" + btopAppId,
+      "btop", "--config", activity.configPath
     ])
   }
 
   function launchBtopHelp() {
+    if (!activity) return
     close()
     Quickshell.execDetached([
       "bash", "-lc",
-      "omarchy-launch-or-focus-tui --app-id=" + btopAppId + " btop "
+      "omarchy-launch-or-focus-tui --app-id=" + btopAppId
+        + " btop --config " + shellQuote(activity.configPath) + " "
         + ">/dev/null 2>&1 & "
         + "for _ in {1..30}; do "
         + "if hyprctl clients -j | jq -e "

--- a/Service.qml
+++ b/Service.qml
@@ -28,13 +28,9 @@ QtObject {
 
   readonly property bool configBusy: _pendingKey !== ""
     || _savingConfig
-    || configDirectoryProcess.running || defaultConfigProcess.running
-  readonly property string configRoot: {
-    var xdg = Quickshell.env("XDG_CONFIG_HOME")
-    return xdg || Quickshell.env("HOME") + "/.config"
-  }
-  readonly property string configDirectory: configRoot + "/btop"
-  readonly property string configPath: configDirectory + "/btop.conf"
+    || defaultConfigProcess.running
+  readonly property string configPath: Quickshell.env("HOME")
+    + "/.config/omarchy/plugins/ilyazar.btop/.btop.conf"
   readonly property var sortingValues: [
     "pid", "program", "arguments", "threads", "user", "memory",
     "cpu lazy", "cpu direct"
@@ -173,9 +169,10 @@ QtObject {
   }
 
   function createConfig() {
-    if (configDirectoryProcess.running || defaultConfigProcess.running) return
-    configDirectoryProcess.command = ["mkdir", "-p", configDirectory]
-    configDirectoryProcess.running = true
+    if (defaultConfigProcess.running) return
+    _defaultConfigOutput = ""
+    _defaultConfigError = ""
+    defaultConfigProcess.running = true
   }
 
   function finishDefaultConfig() {
@@ -257,7 +254,10 @@ QtObject {
     printErrors: false
     onLoaded: root.handleConfigLoaded(text())
     onLoadFailed: function(error) {
-      if (error === FileViewError.FileNotFound) root.createConfig()
+      if (error === FileViewError.FileNotFound) {
+        if (root._pendingKey !== "") root.createConfig()
+        else root.applyConfig("")
+      }
       else root.failConfig("Could not read btop settings: "
         + FileViewError.toString(error))
     }
@@ -304,21 +304,6 @@ QtObject {
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.temperaturePath = String(text).trim()
-    }
-  }
-
-  property Process configDirectoryProcess: Process {
-    id: configDirectoryProcess
-    running: false
-    command: []
-    onExited: function(exitCode) {
-      if (exitCode !== 0) {
-        root.failConfig("Could not create the btop config directory")
-        return
-      }
-      root._defaultConfigOutput = ""
-      root._defaultConfigError = ""
-      defaultConfigProcess.running = true
     }
   }
 


### PR DESCRIPTION
## What changed

- store plugin-controlled btop settings in a private ignored `.btop.conf`
  inside the plugin checkout
- launch both normal and Help btop sessions with that file via `--config`
- never read, create, or modify the user's normal btop configuration
- rely on native checkout removal to remove all plugin-owned btop state

This replaces the global-config path; there is no backup, migration, or
uninstall lifecycle layer.

Fixes #6

## Validation

- `qmllint -I /usr/share/omarchy/shell Service.qml BarWidget.qml
  ActivityIcon.qml`
- `omarchy plugin validate .`
- direct `btop --config` check with isolated `XDG_CONFIG_HOME`: the private
  file was created and the normal btop path remained absent
- structured branch review: no accepted/actionable findings

## Clean Quattro test

Test commit: `56f991ecc85854eeed235a10da70236abd57bb0c`

The native installer clones the default branch. Install disabled, pin the
checkout to this PR commit, validate, then enable:

```bash
omarchy plugin add https://github.com/ilyaZar/btop-quattro-plugin.git --yes
git -C ~/.config/omarchy/plugins/ilyazar.btop fetch origin fix-passive-btop-config
git -C ~/.config/omarchy/plugins/ilyazar.btop checkout --detach 56f991ecc85854eeed235a10da70236abd57bb0c
omarchy plugin validate ~/.config/omarchy/plugins/ilyazar.btop
omarchy-shell shell rescanPlugins
omarchy plugin enable ilyazar.btop --section right
```

Acceptance checks:

1. If `~/.config/btop/` was absent, install, exercise the plugin, and remove
   it; the directory should remain absent.
2. If the directory existed without `btop.conf`, the same cycle should leave
   that directory intact without creating the file.
3. If `btop.conf` existed, record its checksum, change every plugin btop
   setting, open normal btop and Help, then remove the plugin; the checksum
   should be unchanged.
4. While installed, plugin changes should be present only in
   `~/.config/omarchy/plugins/ilyazar.btop/.btop.conf`, and both launch paths
   should use them.
5. Native removal should leave no checkout, Omarchy entry, in-process service,
   or plugin-owned btop state.
