### PR TITLE
feat: add left-click toggle and a bindable toggle script

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -35,6 +35,10 @@ Panel {
   readonly property string keybindingsScript: localPath(
     Qt.resolvedUrl("open-keybindings.sh"))
   readonly property string windowMode: String(setting("windowMode", "Floating"))
+  readonly property string leftClickAction:
+    String(setting("leftClickAction", "Open or focus"))
+  readonly property string toggleScript: localPath(
+    Qt.resolvedUrl("toggle-btop.sh"))
   readonly property int updateMs: intSetting(
     "updateMs", 2000, UpdateInterval.minimum, UpdateInterval.maximum)
   readonly property var updateDraftValue: UpdateInterval.parse(updateDraft)
@@ -73,7 +77,8 @@ Panel {
   readonly property int customPathIndex: iconStyle === "Custom" ? 1 : -1
   readonly property int keybindingsIndex: iconStyle === "Custom" ? 2 : 1
   readonly property int windowModeIndex: keybindingsIndex + 1
-  readonly property int updateIndex: windowModeIndex + 1
+  readonly property int clickActionIndex: windowModeIndex + 1
+  readonly property int updateIndex: clickActionIndex + 1
   readonly property int sortingIndex: updateIndex + 1
   readonly property int treeIndex: updateIndex + 2
   readonly property int backIndex: updateIndex + 3
@@ -157,6 +162,7 @@ Panel {
     }
     pendingLaunch = ""
     if (action === "help") execBtopHelp()
+    else if (action === "toggle") execToggle()
     else execBtop()
   }
 
@@ -164,6 +170,14 @@ Panel {
     Quickshell.execDetached([
       "omarchy-launch-or-focus-tui", "--app-id=" + btopAppId,
       "btop", "--config", activity.configPath
+    ])
+  }
+
+  function execToggle() {
+    Quickshell.execDetached([
+      "bash", toggleScript,
+      "--app-id", btopAppId,
+      "--config", activity.configPath
     ])
   }
 
@@ -192,7 +206,7 @@ Panel {
 
   function launchBtop() {
     close()
-    launchWhenConfigReady("btop")
+    launchWhenConfigReady(leftClickAction === "Toggle" ? "toggle" : "btop")
   }
 
   function launchBtopHelp() {
@@ -337,6 +351,11 @@ Panel {
       var mode = nextChoice(["Floating", "Tiled"], windowMode, direction)
       applyWindowMode(mode)
       persistPluginSetting("windowMode", mode)
+      return
+    }
+    if (index === clickActionIndex) {
+      persistPluginSetting("leftClickAction",
+        nextChoice(["Open or focus", "Toggle"], leftClickAction, direction))
       return
     }
     if (!activity || activity.configBusy) return
@@ -691,6 +710,16 @@ Panel {
               if (on) root.settingsIndex = root.windowModeIndex
             }
             onClicked: root.cycleSetting(root.windowModeIndex, 1)
+          }
+
+          MenuRow {
+            label: "Left click"
+            value: root.leftClickAction
+            hasCursor: root.settingsIndex === root.clickActionIndex
+            onHovered: function(on) {
+              if (on) root.settingsIndex = root.clickActionIndex
+            }
+            onClicked: root.cycleSetting(root.clickActionIndex, 1)
           }
 
           PanelSeparator { foreground: root.foreground }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to btop Activity are documented here.
 
 ## Unreleased
 
+- Add a **Left click** setting (Open or focus / Toggle): with Toggle, clicking
+  the widget while btop is open closes the window instead of focusing it. The
+  shipped `toggle-btop.sh` implements the toggle and can be bound directly to
+  the Activity keybinding, so the same key opens and closes btop (@gw7523).
+
 ## 0.2.0 - 2026-08-21
 
 - Rename the GitHub repository to `omarchy-btop-activity` while keeping the

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The plugin keeps a short list of useful controls before opening btop:
 | Tray icon       | Meters, CPU, Pulse, or a custom image    |
 | Keybindings     | opens the Omarchy user bindings file     |
 | Window mode     | floating or tiled                        |
+| Left click      | open or focus, or toggle (close if open) |
 | Update interval | any whole number from 100 ms to one day  |
 | Process sorting | lazy CPU, direct CPU, memory, or program |
 | Process tree    | on or off                                |
@@ -91,6 +92,20 @@ Omarchy assigns `Super+Ctrl+T` to btop by default. To replace it, e.g. with
 hl.unbind("SUPER + CTRL + T")
 o.bind("SUPER + CTRL + ALT + G", "Activity", { tui = "btop" })
 ```
+
+To make the same key both open and close btop, point the binding at the
+plugin's toggle script instead (pairs naturally with the **Left click →
+Toggle** setting):
+
+```lua
+hl.unbind("SUPER + CTRL + T")
+o.bind("SUPER + CTRL + T", "Activity",
+  os.getenv("HOME") .. "/.config/omarchy/plugins/ilyazar.btop/toggle-btop.sh")
+```
+
+Invoked bare like this, the script reads the configured window mode from
+`shell.json`, closes any open btop window it launched (in either mode), and
+otherwise launches btop with the plugin's runtime config when it exists.
 
 After Hyprland reloads, the settings row shows the effective shortcut, or
 `Unbound` when no Activity binding remains.

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
       "iconStyle": "CPU",
       "customIconPath": "",
       "windowMode": "Floating",
+      "leftClickAction": "Open or focus",
       "updateMs": 2000,
       "procSorting": "cpu lazy",
       "procTree": false
@@ -46,6 +47,13 @@
         "label": "btop window mode",
         "options": ["Floating", "Tiled"],
         "defaultValue": "Floating"
+      },
+      {
+        "key": "leftClickAction",
+        "type": "enum",
+        "label": "Left click",
+        "options": ["Open or focus", "Toggle"],
+        "defaultValue": "Open or focus"
       }
     ]
   }

--- a/tests/test_toggle_btop.sh
+++ b/tests/test_toggle_btop.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+TEMP_ROOT="$(mktemp -d)"
+readonly TEST_DIR PLUGIN_ROOT TEMP_ROOT
+trap 'rm -rf -- "$TEMP_ROOT"' EXIT
+
+readonly MOCK_BIN="$TEMP_ROOT/bin"
+readonly LOG="$TEMP_ROOT/calls.log"
+readonly CLIENTS="$TEMP_ROOT/clients.json"
+
+mkdir -p "$MOCK_BIN"
+
+cat >"$MOCK_BIN/hyprctl" <<MOCK
+#!/bin/bash
+if [[ \$1 == clients ]]; then cat "$CLIENTS"; exit 0; fi
+if [[ \$1 == dispatch ]]; then shift; printf 'dispatch %s\n' "\$*" >>"$LOG"; exit 0; fi
+exit 1
+MOCK
+
+cat >"$MOCK_BIN/omarchy-launch-or-focus-tui" <<MOCK
+#!/bin/bash
+printf 'launch %s\n' "\$*" >>"$LOG"
+MOCK
+
+chmod +x "$MOCK_BIN/hyprctl" "$MOCK_BIN/omarchy-launch-or-focus-tui"
+
+run_toggle() {
+  : >"$LOG"
+  env PATH="$MOCK_BIN:$PATH" \
+    HOME="$TEMP_ROOT" \
+    XDG_CONFIG_HOME="$TEMP_ROOT/config" \
+    XDG_RUNTIME_DIR="$TEMP_ROOT/runtime" \
+    bash "$PLUGIN_ROOT/toggle-btop.sh" "$@"
+}
+
+mkdir -p "$TEMP_ROOT/runtime" "$TEMP_ROOT/config/omarchy"
+
+# An open floating window is closed and nothing new is launched.
+printf '[{"class": "org.omarchy.btop", "address": "0xabc", "pid": 4242}]' >"$CLIENTS"
+run_toggle --app-id org.omarchy.btop --config "$TEMP_ROOT/runtime/ilyazar-btop.conf"
+grep -q 'dispatch hl.dsp.window.close({ window = "address:0xabc" })' "$LOG"
+! grep -q '^launch' "$LOG"
+
+# Windows from either mode are closed, so switching modes cannot strand one.
+printf '[{"class": "org.omarchy.btop_tiled", "address": "0xdef", "pid": 4243}]' >"$CLIENTS"
+run_toggle --app-id org.omarchy.btop
+grep -q 'address:0xdef' "$LOG"
+! grep -q '^launch' "$LOG"
+
+# No window: launches with the given app id and config.
+printf '[]' >"$CLIENTS"
+: >"$TEMP_ROOT/runtime/ilyazar-btop.conf"
+run_toggle --app-id org.omarchy.btop --config "$TEMP_ROOT/runtime/ilyazar-btop.conf"
+grep -q "launch --app-id=org.omarchy.btop btop --config $TEMP_ROOT/runtime/ilyazar-btop.conf" "$LOG"
+
+# Bare invocation (a keybinding): window mode comes from shell.json and the
+# runtime config is picked up when present.
+printf '{"bar":{"layout":{"right":[{"id":"ilyazar.btop","windowMode":"Tiled"}]}}}' \
+  >"$TEMP_ROOT/config/omarchy/shell.json"
+run_toggle
+grep -q "launch --app-id=org.omarchy.btop_tiled btop --config $TEMP_ROOT/runtime/ilyazar-btop.conf" "$LOG"
+
+# Bare invocation without a runtime config launches plain, like the stock binding.
+rm "$TEMP_ROOT/runtime/ilyazar-btop.conf" "$TEMP_ROOT/config/omarchy/shell.json"
+run_toggle
+grep -q 'launch --app-id=org.omarchy.btop btop$' "$LOG"
+
+echo "toggle-btop tests passed"

--- a/toggle-btop.sh
+++ b/toggle-btop.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Toggle the plugin's btop window: close it when it is open, launch it
+# otherwise. Used by the bar widget when "Left click" is set to Toggle, and
+# directly usable from a Hyprland keybinding so the same key opens and
+# closes btop:
+#
+#   hl.unbind("SUPER + CTRL + T")
+#   o.bind("SUPER + CTRL + T", "Activity",
+#     os.getenv("HOME") .. "/.config/omarchy/plugins/ilyazar.btop/toggle-btop.sh")
+#
+# The widget passes --app-id and --config explicitly. Invoked bare (from a
+# keybinding), the script derives the window mode from shell.json and uses
+# the plugin's runtime config when it exists — falling back to a plain
+# launch, matching Omarchy's stock btop binding, when it does not.
+
+set -euo pipefail
+
+APP_ID=""
+CONFIG=""
+
+usage() {
+  echo "Usage: toggle-btop.sh [--app-id ID] [--config PATH]"
+  echo "Close the plugin's btop window if open, otherwise launch it."
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --app-id)
+      APP_ID=$2
+      shift 2
+      ;;
+    --config)
+      CONFIG=$2
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z $APP_ID ]]; then
+  mode=$(jq -r '
+    .. | objects | select(.id? == "ilyazar.btop") | .windowMode // empty
+  ' "${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/shell.json" 2>/dev/null |
+    head -n 1 || true)
+  if [[ ${mode:-} == Tiled ]]; then
+    APP_ID="org.omarchy.btop_tiled"
+  else
+    APP_ID="org.omarchy.btop"
+  fi
+fi
+
+if [[ -z $CONFIG ]]; then
+  candidate="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ilyazar-btop.conf"
+  [[ -f $candidate ]] && CONFIG=$candidate
+fi
+
+close_one() {
+  local address=$1 pid=$2
+  if [[ -n $address ]]; then
+    # Omarchy's Hyprland speaks Lua dispatchers; plain closewindow is the
+    # fallback for a stock compositor.
+    if hyprctl dispatch \
+      "hl.dsp.window.close({ window = \"address:${address}\" })" \
+      >/dev/null 2>&1; then
+      return 0
+    fi
+    if hyprctl dispatch closewindow "address:${address}" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+  if [[ -n $pid && $pid != 0 ]]; then
+    kill "$pid" >/dev/null 2>&1 && return 0
+  fi
+  return 1
+}
+
+clients_json=$(hyprctl clients -j 2>/dev/null || true)
+[[ -n $clients_json ]] || clients_json='[]'
+
+# Close every window the plugin may have opened, in either window mode —
+# switching Floating/Tiled while a window is open must not strand the old one.
+mapfile -t rows < <(
+  jq -r '
+    .[]
+    | select(.class == "org.omarchy.btop" or .class == "org.omarchy.btop_tiled")
+    | [(.address // ""), ((.pid // 0) | tostring)]
+    | @tsv
+  ' <<<"$clients_json"
+)
+
+if ((${#rows[@]} > 0)); then
+  closed=0
+  for row in "${rows[@]}"; do
+    address=${row%%$'\t'*}
+    pid=${row#*$'\t'}
+    if close_one "$address" "$pid"; then
+      closed=1
+    fi
+  done
+  ((closed))
+  exit 0
+fi
+
+command=(omarchy-launch-or-focus-tui "--app-id=$APP_ID" btop)
+[[ -n $CONFIG ]] && command+=(--config "$CONFIG")
+exec "${command[@]}"


### PR DESCRIPTION
## What

Two configurable ways to make btop close the same way it opens:

1. A new **Left click** setting — `Open or focus` (the default, current behavior) / `Toggle`. With Toggle, clicking the widget while btop is open closes the window instead of focusing it.
2. A shipped **`toggle-btop.sh`** implementing that toggle, directly bindable to the Activity keybinding so the same key opens *and* closes btop:

```lua
hl.unbind("SUPER + CTRL + T")
o.bind("SUPER + CTRL + T", "Activity",
  os.getenv("HOME") .. "/.config/omarchy/plugins/ilyazar.btop/toggle-btop.sh")
```

## Design notes

- One toggle implementation for both paths: the widget passes `--app-id`/`--config` explicitly (routed through the existing `launchWhenConfigReady` gate so the runtime config is materialized first); a bare invocation from a keybinding derives the window mode from `shell.json` and uses the runtime config **only when it already exists** — a missing config launches plain, like the stock binding, rather than creating one (mindful of #6).
- Closing matches windows from **either** window mode, so flipping Floating/Tiled while a window is open can't strand the old one. Close order: Omarchy's `hl.dsp.window.close` Lua dispatcher, then plain `closewindow`, then SIGTERM — same convention as the existing `execBtopHelp` dispatcher usage.
- Settings UI gets a `Left click` MenuRow under Window mode (keyboard cycling included), with the index chain shifted; manifest schema, README (settings table + keybinding example), and CHANGELOG updated. Default preserves current behavior exactly.

## Testing

- New `tests/test_toggle_btop.sh` (mocked `hyprctl` + launcher, real `jq`): open-window → close dispatched and nothing launched; either-mode close; explicit launch args; bare invocation deriving Tiled from `shell.json`; bare invocation without a runtime config launching plain.
- Existing `test_runtime_config_cleanup.sh` still passes; `omarchy plugin validate .` passes.
- Live on Omarchy: clicking toggles open/close in Floating mode, and the rebound `Super+Ctrl+T` opens then closes the same window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01121sXsXetn9HztudfV3maz