### PR TITLE
fix: render tooltip and stream intel gpu

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -58,7 +58,7 @@ Panel {
   readonly property bool gpuTemperatureAvailable:
     activity && activity.gpuTemperature >= 0
   readonly property string gpuTemperatureText: gpuTemperatureAvailable
-    ? Math.round(activity.gpuTemperature) + "°C" : "<unavailable>"
+    ? Math.round(activity.gpuTemperature) + "°C" : "unavailable"
   readonly property string tooltip: alignedTooltip(
     customIconInvalid ? "Custom icon" : (activity && activity.available
       ? "RAM: " + Math.round(activity.memoryUsage) + "%" : "RAM: --"),

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -59,14 +59,14 @@ Panel {
     activity && activity.gpuTemperature >= 0
   readonly property string gpuTemperatureText: gpuTemperatureAvailable
     ? Math.round(activity.gpuTemperature) + "°C" : "<unavailable>"
-  readonly property string tooltip: styledTooltip(alignedTooltip(
+  readonly property string tooltip: alignedTooltip(
     customIconInvalid ? "Custom icon" : (activity && activity.available
       ? "RAM: " + Math.round(activity.memoryUsage) + "%" : "RAM: --"),
     customIconInvalid ? "Unavailable" : (activity && activity.available
       ? "CPU: " + Math.round(activity.cpuUsage) + "%" + cpuTemperatureSuffix
       : "CPU: --"),
     "GPU: " + gpuUsageText + " • " + gpuTemperatureText
-  ))
+  )
   readonly property var sortingChoices: [
     "cpu lazy", "cpu direct", "memory", "program"
   ]
@@ -108,19 +108,6 @@ Panel {
       + "\n" + padRight(secondMetric, 27) + "    "
       + padLeft("Right click: menu", 17)
       + "\n" + padRight(thirdMetric, 48)
-  }
-
-  function styledTooltip(value) {
-    if (gpuTemperatureAvailable) return value
-    var escaped = String(value)
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-    return "<pre>" + escaped.replace(
-      "&lt;unavailable&gt;",
-      "<font color=\"" + String(Qt.darker(Color.tooltip.text, 1.7))
-        + "\">&lt;unavailable&gt;</font>"
-    ) + "</pre>"
   }
 
   function shellQuote(value) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to btop Activity are documented here.
 
 ## Unreleased
 
+- Render the bar tooltip as plain text. The bar draws `tooltipText` with
+  `textFormat: Text.PlainText`, so the `<pre>`/`<font>` wrapper used to dim
+  `<unavailable>` was shown to the user as literal tag text whenever GPU
+  temperature was unreadable (@gw7523).
+
 ## 0.2.0 - 2026-08-21
 
 - Rename the GitHub repository to `omarchy-btop-activity` while keeping the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Notable changes to btop Activity are documented here.
   `textFormat: Text.PlainText`, so the `<pre>`/`<font>` wrapper used to dim
   `<unavailable>` was shown to the user as literal tag text whenever GPU
   temperature was unreadable (@gw7523).
+- Stream Intel GPU usage immediately after installation without a privileged
+  helper.
 
 ## 0.2.0 - 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ needs the distribution's ROCm SMI library (`rocm-smi-lib` on Arch).
 ## Use
 
 The plugin reads GPU telemetry from the kernel driver. If that driver does not
-publish a temperature sensor, the hover shows a dimmed `<unavailable>`. If
-something fails here, GPU and driver combinations can be messy, so feel free to
-file an issue.
+publish a temperature sensor, the hover shows `unavailable`. If something fails
+here, GPU and driver combinations can be messy, so feel free to file an issue.
 
 AMD usage and temperature are read directly from DRM sysfs. NVIDIA uses NVML,
 while Intel `i915` usage is sampled from the same Linux performance counters
@@ -161,8 +160,8 @@ signal only after a successful change. Disabling or removing the plugin restores
 a file that existed before the plugin was enabled, or removes the file it
 created.
 
-GPU temperature depends on driver support. If unavailable, the hover shows
-`<unavailable>`. For AMD temperature monitoring in btop, install ROCm SMI:
+GPU temperature depends on driver support. If unavailable, the hover says so.
+For AMD temperature monitoring in btop, install ROCm SMI:
 
 ```bash
 sudo pacman -S rocm-smi-lib

--- a/README.md
+++ b/README.md
@@ -36,21 +36,19 @@ The plugin reads GPU telemetry from the kernel driver. If that driver does not
 publish a temperature sensor, the hover shows `unavailable`. If something fails
 here, GPU and driver combinations can be messy, so feel free to file an issue.
 
-AMD usage and temperature are read directly from DRM sysfs. NVIDIA uses NVML,
-while Intel `i915` usage is sampled from the same Linux performance counters
-used by btop. Install the plugin's narrow helper once to enable the native
-backends:
+AMD usage and temperature are read directly from DRM sysfs. Intel usage is
+sampled from per-client DRM accounting and works immediately after installation.
+NVIDIA uses NVML through a narrow helper that can be built once with:
 
 ```bash
 ~/.config/omarchy/plugins/ilyazar.btop/setup-gpu-helper.sh
 ```
 
-The helper is built locally. On Intel it receives only `cap_perfmon`; NVIDIA
-uses the driver-provided NVML library without elevated privileges. Intel
-integrated GPUs commonly expose package temperature rather than a separate GPU
-sensor, so temperature can remain unavailable even while usage is working.
-Building requires a C compiler and `setcap` from `libcap`. NVIDIA monitoring
-also requires the official driver-provided `libnvidia-ml` library, as btop does.
+The NVIDIA helper is built locally and runs without elevated privileges.
+Building requires a C compiler and the official driver's `libnvidia-ml` library.
+Intel integrated GPUs commonly expose package temperature rather than a
+separate GPU sensor, so temperature can remain unavailable even while usage is
+working.
 
 ## Demo
 
@@ -122,7 +120,7 @@ Planned work stays at the top. Shipped entries come from
 
 | Release | State   | Date       | What changed                                           |
 | ------- | ------- | ---------- | ------------------------------------------------------ |
-| Next    | planned | TBD        | add details when the next release is planned           |
+| Next    | planned | TBD        | fix hover markup and stream Intel GPU data             |
 | 0.2.0   | shipped | 2026-08-21 | make the release table clean and easy to scan          |
 | 0.1.10  | shipped | 2026-08-21 | choose any update interval or step through presets     |
 |         |         |            | restore settings when disabling or removing the plugin |

--- a/Service.qml
+++ b/Service.qml
@@ -50,6 +50,8 @@ QtObject {
     (Quickshell.env("XDG_DATA_HOME")
       || Quickshell.env("HOME") + "/.local/share")
       + "/ilyazar-btop/gpu-telemetry"
+  readonly property string gpuFdinfoPath:
+    localPath(Qt.resolvedUrl("gpu-fdinfo.sh"))
   readonly property var sortingValues: [
     "pid", "program", "arguments", "threads", "user", "memory",
     "cpu lazy", "cpu direct"
@@ -122,13 +124,17 @@ QtObject {
     if (!statsProcess.running) statsProcess.running = true
     if (temperaturePath !== "") temperatureFile.reload()
     if (gpuUsagePath !== "") gpuUsageFile.reload()
-    else if (gpuBackend === "helper" && !gpuHelperProcess.running) {
+    else if ((gpuBackend === "fdinfo" || gpuBackend === "helper")
+        && !gpuTelemetryProcess.running) {
       var sampleMs = Math.max(50, Math.min(250, updateMs / 4))
-      gpuHelperProcess.command = [
-        "sh", "-c", "[ -x \"$1\" ] || exit 127; exec \"$1\" \"$2\"",
-        "sh", gpuHelperPath, String(Math.round(sampleMs))
-      ]
-      gpuHelperProcess.running = true
+      gpuTelemetryProcess.command = gpuBackend === "fdinfo"
+        ? ["bash", gpuFdinfoPath, String(Math.round(sampleMs))]
+        : [
+            "sh", "-c",
+            "[ -x \"$1\" ] || exit 127; exec \"$1\"",
+            "sh", gpuHelperPath
+          ]
+      gpuTelemetryProcess.running = true
     }
     if (gpuTemperaturePath !== "") gpuTemperatureFile.reload()
   }
@@ -367,11 +373,12 @@ QtObject {
         gpuBackend = "sysfs"
         gpuUsagePath = fields[1] || ""
       }
+      else if (fields[0] === "gpu_fdinfo") gpuBackend = "fdinfo"
       else if (fields[0] === "gpu_helper") gpuBackend = "helper"
       else if (fields[0] === "gpu_temperature")
         gpuTemperaturePath = fields[1] || ""
     }
-    if (gpuBackend === "" || gpuUsagePath === "") gpuUsage = -1
+    if (gpuBackend === "") gpuUsage = -1
     if (gpuTemperaturePath === "") gpuTemperature = -1
   }
 
@@ -462,17 +469,18 @@ QtObject {
     }
   }
 
-  property Process gpuHelperProcess: Process {
-    id: gpuHelperProcess
+  property Process gpuTelemetryProcess: Process {
+    id: gpuTelemetryProcess
     running: false
     command: []
     stdout: StdioCollector {
-      id: gpuHelperStdout
+      id: gpuTelemetryStdout
       waitForEnd: true
     }
     onExited: function(exitCode) {
-      if (root.gpuBackend !== "helper") return
-      if (exitCode === 0) root.applyGpuTelemetry(gpuHelperStdout.text)
+      if (root.gpuBackend !== "fdinfo" && root.gpuBackend !== "helper")
+        return
+      if (exitCode === 0) root.applyGpuTelemetry(gpuTelemetryStdout.text)
       else {
         root.gpuUsage = -1
         if (root.gpuTemperaturePath === "") root.gpuTemperature = -1
@@ -513,11 +521,13 @@ QtObject {
         + "done; [ -n \"$fallback\" ] && "
         + "printf 'gpu_temperature\\t%s\\n' \"$fallback\"; break; "
         + "done; exit 0; done; "
-        + "candidate=${nvidia:-$intel}; helper=; "
-        + "[ -d /proc/driver/nvidia/gpus ] && helper=1; "
-        + "[ -d /sys/bus/event_source/devices/i915 ] && helper=1; "
-        + "[ -n \"$candidate$helper\" ] || exit 0; "
-        + "printf 'gpu_helper\\n'; "
+        + "candidate=; "
+        + "if [ -n \"$nvidia\" ] "
+        + "&& [ -d /proc/driver/nvidia/gpus ]; then "
+        + "candidate=$nvidia; printf 'gpu_helper\\n'; "
+        + "elif [ -n \"$intel\" ]; then candidate=$intel; "
+        + "printf 'gpu_fdinfo\\n'; "
+        + "else exit 0; fi; "
         + "for h in \"$candidate\"/hwmon/hwmon*; do "
         + "[ -d \"$h\" ] || continue; for f in \"$h\"/temp*_input; do "
         + "[ -r \"$f\" ] || continue; "

--- a/gpu-fdinfo.sh
+++ b/gpu-fdinfo.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+interval_ms=${1:-250}
+proc_root=${BTOP_GPU_PROC_ROOT:-/proc}
+dri_root=${BTOP_GPU_DRI_ROOT:-/dev/dri}
+
+[[ $interval_ms =~ ^[0-9]+$ ]] || exit 2
+((interval_ms >= 50 && interval_ms <= 5000)) || exit 2
+
+snapshot() {
+  local device fd file process
+  local -a devices=()
+  local -a files=()
+
+  for device in "$dri_root"/card[0-9]* "$dri_root"/renderD[0-9]*; do
+    [[ -e $device ]] && devices+=("$device")
+  done
+  ((${#devices[@]} > 0)) || return 0
+
+  for process in "$proc_root"/[0-9]*; do
+    [[ -O $process ]] || continue
+    for fd in "$process"/fd/[0-9]*; do
+      for device in "${devices[@]}"; do
+        [[ $fd -ef $device ]] || continue
+        file=$process/fdinfo/${fd##*/}
+        [[ -r $file ]] && files+=("$file")
+        break
+      done
+    done
+  done
+  ((${#files[@]} > 0)) || return 0
+
+  { grep -H -E '^drm-(client-id|pdev|engine-)' \
+      "${files[@]}" 2>/dev/null || true; } |
+    awk '
+      {
+        separator = index($0, ":")
+        file = substr($0, 1, separator - 1)
+        line = substr($0, separator + 1)
+        if (file != previous_file) {
+          client = ""
+          device = "unknown"
+          previous_file = file
+        }
+
+        separator = match(line, /:[[:space:]]+/)
+        label = substr(line, 1, separator - 1)
+        value = substr(line, separator + RLENGTH)
+        if (label == "drm-client-id") client = value
+        else if (label == "drm-pdev") device = value
+        else if (label ~ /^drm-engine-/ && client != "") {
+          if (value !~ /^[0-9]+ ns$/) next
+          sub(/^drm-engine-/, "", label)
+          sub(/ ns$/, "", value)
+          key = device "|" client "|" label
+          if (value + 0 > maximum[key]) maximum[key] = value + 0
+        }
+      }
+      END {
+        for (key in maximum) printf "%s\t%.0f\n", key, maximum[key]
+      }
+    '
+}
+
+declare -A before=() totals=()
+started_ns=$(date +%s%N)
+while IFS=$'\t' read -r key value; do
+  before[$key]=$value
+done < <(snapshot)
+
+printf -v delay '%d.%03d' "$((interval_ms / 1000))" \
+  "$((interval_ms % 1000))"
+sleep "$delay"
+
+ended_ns=$(date +%s%N)
+while IFS=$'\t' read -r key value; do
+  [[ -v before[$key] ]] || continue
+  ((value >= before[$key])) || continue
+  device=${key%%|*}
+  engine=${key##*|}
+  total_key=$device'|'$engine
+  totals[$total_key]=$((
+    ${totals[$total_key]:-0} + value - before[$key]
+  ))
+done < <(snapshot)
+
+((${#totals[@]} > 0)) || exit 3
+interval_ns=$((ended_ns - started_ns))
+maximum=0
+for value in "${totals[@]}"; do
+  ((value > maximum)) && maximum=$value
+done
+((maximum > interval_ns)) && maximum=$interval_ns
+hundredths=$((maximum * 10000 / interval_ns))
+printf 'usage\t%d.%02d\n' "$((hundredths / 100))" \
+  "$((hundredths % 100))"

--- a/gpu-fdinfo.sh
+++ b/gpu-fdinfo.sh
@@ -4,14 +4,18 @@ set -euo pipefail
 interval_ms=${1:-250}
 proc_root=${BTOP_GPU_PROC_ROOT:-/proc}
 dri_root=${BTOP_GPU_DRI_ROOT:-/dev/dri}
+declare -a fdinfo_files=()
 
 [[ $interval_ms =~ ^[0-9]+$ ]] || exit 2
 ((interval_ms >= 50 && interval_ms <= 5000)) || exit 2
 
-snapshot() {
+discover_files() {
   local device fd file process
   local -a devices=()
-  local -a files=()
+  local -a directories=()
+  local -a expression=()
+
+  fdinfo_files=()
 
   for device in "$dri_root"/card[0-9]* "$dri_root"/renderD[0-9]*; do
     [[ -e $device ]] && devices+=("$device")
@@ -20,19 +24,31 @@ snapshot() {
 
   for process in "$proc_root"/[0-9]*; do
     [[ -O $process ]] || continue
-    for fd in "$process"/fd/[0-9]*; do
-      for device in "${devices[@]}"; do
-        [[ $fd -ef $device ]] || continue
-        file=$process/fdinfo/${fd##*/}
-        [[ -r $file ]] && files+=("$file")
-        break
-      done
-    done
+    [[ -d $process/fd ]] && directories+=("$process/fd")
   done
-  ((${#files[@]} > 0)) || return 0
+  ((${#directories[@]} > 0)) || return 0
 
-  { grep -H -E '^drm-(client-id|pdev|engine-)' \
-      "${files[@]}" 2>/dev/null || true; } |
+  for device in "${devices[@]}"; do
+    ((${#expression[@]} > 0)) && expression+=(-o)
+    expression+=(-samefile "$device")
+  done
+
+  while IFS= read -r -d '' fd; do
+    file=${fd%/fd/*}/fdinfo/${fd##*/}
+    [[ -r $file ]] && fdinfo_files+=("$file")
+  done < <(
+    printf '%s\0' "${directories[@]}" |
+      find -L -files0-from - -mindepth 1 -maxdepth 1 \
+        \( "${expression[@]}" \) -print0 2>/dev/null
+  )
+}
+
+snapshot() {
+  ((${#fdinfo_files[@]} > 0)) || return 0
+
+  { printf '%s\0' "${fdinfo_files[@]}" |
+      xargs -0 -r grep -H -E '^drm-(client-id|pdev|engine-)' \
+        -- 2>/dev/null || true; } |
     awk '
       {
         separator = index($0, ":")
@@ -54,7 +70,8 @@ snapshot() {
           sub(/^drm-engine-/, "", label)
           sub(/ ns$/, "", value)
           key = device "|" client "|" label
-          if (value + 0 > maximum[key]) maximum[key] = value + 0
+          if (!(key in maximum) || value + 0 > maximum[key])
+            maximum[key] = value + 0
         }
       }
       END {
@@ -63,17 +80,19 @@ snapshot() {
     '
 }
 
+discover_files
 declare -A before=() totals=()
-started_ns=$(date +%s%N)
+first_started_ns=$(date +%s%N)
 while IFS=$'\t' read -r key value; do
   before[$key]=$value
 done < <(snapshot)
+first_ended_ns=$(date +%s%N)
 
 printf -v delay '%d.%03d' "$((interval_ms / 1000))" \
   "$((interval_ms % 1000))"
 sleep "$delay"
 
-ended_ns=$(date +%s%N)
+second_started_ns=$(date +%s%N)
 while IFS=$'\t' read -r key value; do
   [[ -v before[$key] ]] || continue
   ((value >= before[$key])) || continue
@@ -84,9 +103,11 @@ while IFS=$'\t' read -r key value; do
     ${totals[$total_key]:-0} + value - before[$key]
   ))
 done < <(snapshot)
+second_ended_ns=$(date +%s%N)
 
 ((${#totals[@]} > 0)) || exit 3
-interval_ns=$((ended_ns - started_ns))
+interval_ns=$(((second_started_ns + second_ended_ns
+  - first_started_ns - first_ended_ns) / 2))
 maximum=0
 for value in "${totals[@]}"; do
   ((value > maximum)) && maximum=$value

--- a/gpu-telemetry.c
+++ b/gpu-telemetry.c
@@ -1,20 +1,8 @@
-#define _GNU_SOURCE
-
 #include <dlfcn.h>
-#include <errno.h>
-#include <glob.h>
-#include <linux/perf_event.h>
 #include <math.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/syscall.h>
-#include <time.h>
-#include <unistd.h>
 
-#define MAX_EVENTS 64
 #define NVML_SUCCESS 0
 #define NVML_TEMPERATURE_GPU 0
 
@@ -27,21 +15,9 @@ typedef struct {
 } nvmlUtilization_t;
 
 struct telemetry {
-  const char *backend;
   double usage;
   double temperature;
   bool has_temperature;
-};
-
-struct counter {
-  int fd;
-  uint64_t value;
-  uint64_t enabled;
-};
-
-struct sample {
-  uint64_t value;
-  uint64_t enabled;
 };
 
 static void *load_symbol(void *library, const char *name) {
@@ -117,259 +93,25 @@ static int collect_nvidia(struct telemetry *telemetry) {
 
   shutdown();
   dlclose(library);
-  if (!found)
-    return -1;
-
-  telemetry->backend = "nvidia";
-  return 0;
+  return found ? 0 : -1;
 }
 
-static int perf_event_open(struct perf_event_attr *attr, int cpu) {
-  return syscall(SYS_perf_event_open, attr, -1, cpu, -1, 0);
-}
-
-static int read_text(const char *path, char *buffer, size_t size) {
-  FILE *file = fopen(path, "r");
-  if (file == NULL)
-    return -1;
-
-  if (fgets(buffer, (int)size, file) == NULL) {
-    fclose(file);
-    return -1;
-  }
-
-  fclose(file);
-  return 0;
-}
-
-static int parse_number(const char *text, uint64_t *value) {
-  errno = 0;
-  char *end = NULL;
-  unsigned long long parsed = strtoull(text, &end, 0);
-  if (errno != 0 || end == text)
-    return -1;
-
-  *value = (uint64_t)parsed;
-  return 0;
-}
-
-static int event_type_path(const char *event_path, char *path, size_t size) {
-  const char *events = strstr(event_path, "/events/");
-  if (events == NULL)
-    return -1;
-
-  size_t root_length = (size_t)(events - event_path);
-  if (root_length + sizeof("/type") > size)
-    return -1;
-
-  memcpy(path, event_path, root_length);
-  memcpy(path + root_length, "/type", sizeof("/type"));
-  return 0;
-}
-
-static int read_event_definition(const char *event_path, uint32_t *type,
-                                 uint64_t *config) {
-  char buffer[256];
-  char type_path[512];
-
-  if (read_text(event_path, buffer, sizeof(buffer)) != 0)
-    return -1;
-  char *definition = strstr(buffer, "config=");
-  if (definition == NULL || parse_number(definition + 7, config) != 0)
-    return -1;
-
-  if (event_type_path(event_path, type_path, sizeof(type_path)) != 0)
-    return -1;
-  if (read_text(type_path, buffer, sizeof(buffer)) != 0)
-    return -1;
-
-  uint64_t parsed_type = 0;
-  if (parse_number(buffer, &parsed_type) != 0 || parsed_type > UINT32_MAX)
-    return -1;
-
-  *type = (uint32_t)parsed_type;
-  return 0;
-}
-
-static int open_counter(uint32_t type, uint64_t config) {
-  struct perf_event_attr attr = {0};
-  attr.type = type;
-  attr.size = sizeof(attr);
-  attr.config = config;
-  attr.read_format = PERF_FORMAT_TOTAL_TIME_ENABLED;
-
-  long cpu_count = sysconf(_SC_NPROCESSORS_CONF);
-  if (cpu_count < 1)
-    cpu_count = 1;
-
-  for (int cpu = 0; cpu < cpu_count; cpu++) {
-    int fd = perf_event_open(&attr, cpu);
-    if (fd >= 0)
-      return fd;
-    if (errno != EINVAL)
-      break;
-  }
-
-  return -1;
-}
-
-static int read_counter(struct counter *counter) {
-  struct sample sample = {0};
-  ssize_t bytes = read(counter->fd, &sample, sizeof(sample));
-  if (bytes != (ssize_t)sizeof(sample))
-    return -1;
-
-  counter->value = sample.value;
-  counter->enabled = sample.enabled;
-  return 0;
-}
-
-static void close_counters(struct counter *counters, size_t count) {
-  for (size_t i = 0; i < count; i++) {
-    if (counters[i].fd >= 0)
-      close(counters[i].fd);
-  }
-}
-
-static size_t discover_counters(struct counter *counters) {
-  const char *patterns[] = {
-      "/sys/bus/event_source/devices/i915*/events/*-busy",
-  };
-  size_t count = 0;
-
-  for (size_t pattern = 0; pattern < sizeof(patterns) / sizeof(patterns[0]);
-       pattern++) {
-    glob_t matches = {0};
-    int result = glob(patterns[pattern], 0, NULL, &matches);
-    if (result != 0 && result != GLOB_NOMATCH) {
-      globfree(&matches);
-      continue;
-    }
-
-    for (size_t i = 0; i < matches.gl_pathc && count < MAX_EVENTS; i++) {
-      uint32_t type = 0;
-      uint64_t config = 0;
-      if (read_event_definition(matches.gl_pathv[i], &type, &config) != 0)
-        continue;
-
-      int fd = open_counter(type, config);
-      if (fd < 0)
-        continue;
-      counters[count++] = (struct counter){.fd = fd};
-    }
-
-    globfree(&matches);
-  }
-
-  return count;
-}
-
-static int collect_intel(struct telemetry *telemetry, int interval_ms) {
-  struct counter counters[MAX_EVENTS];
-  for (size_t i = 0; i < MAX_EVENTS; i++)
-    counters[i].fd = -1;
-
-  size_t count = discover_counters(counters);
-  if (count == 0)
-    return -1;
-
-  size_t ready = 0;
-  for (size_t i = 0; i < count; i++) {
-    if (read_counter(&counters[i]) == 0) {
-      ready++;
-    } else {
-      close_counters(counters + i, 1);
-      counters[i].fd = -1;
-    }
-  }
-  if (ready == 0) {
-    close_counters(counters, count);
-    return -1;
-  }
-
-  struct timespec delay = {
-      .tv_sec = interval_ms / 1000,
-      .tv_nsec = (long)(interval_ms % 1000) * 1000000L,
-  };
-  while (nanosleep(&delay, &delay) != 0) {
-    if (errno != EINTR) {
-      close_counters(counters, count);
-      return -1;
-    }
-  }
-
-  double maximum = -1.0;
-  for (size_t i = 0; i < count; i++) {
-    if (counters[i].fd < 0)
-      continue;
-
-    uint64_t previous_value = counters[i].value;
-    uint64_t previous_enabled = counters[i].enabled;
-    if (read_counter(&counters[i]) != 0)
-      continue;
-    if (counters[i].value < previous_value ||
-        counters[i].enabled <= previous_enabled)
-      continue;
-
-    uint64_t value_delta = counters[i].value - previous_value;
-    uint64_t enabled_delta = counters[i].enabled - previous_enabled;
-    double usage = (double)value_delta * 100.0 / (double)enabled_delta;
-    if (!isfinite(usage) || usage < 0.0)
-      continue;
-    if (usage > 100.0)
-      usage = 100.0;
-    if (usage > maximum)
-      maximum = usage;
-  }
-
-  close_counters(counters, count);
-  if (maximum < 0.0)
-    return -1;
-
-  telemetry->backend = "intel";
-  telemetry->usage = maximum;
-  return 0;
-}
-
-static int parse_interval(const char *argument) {
-  if (argument == NULL)
-    return 100;
-
-  errno = 0;
-  char *end = NULL;
-  long value = strtol(argument, &end, 10);
-  if (errno != 0 || end == argument || *end != '\0' || value < 50 ||
-      value > 5000)
-    return -1;
-
-  return (int)value;
-}
-
-int main(int argc, char **argv) {
-  int interval_ms = parse_interval(argc > 1 ? argv[1] : NULL);
-  if (interval_ms < 0) {
-    fprintf(stderr, "usage: %s [interval-ms: 50..5000]\n", argv[0]);
-    return 2;
-  }
-
+int main(void) {
   struct telemetry telemetry = {
-      .backend = NULL,
       .usage = -1.0,
       .temperature = -1.0,
       .has_temperature = false,
   };
 
-  if (collect_nvidia(&telemetry) != 0 &&
-      collect_intel(&telemetry, interval_ms) != 0) {
-    fprintf(stderr, "no supported GPU telemetry backend\n");
+  if (collect_nvidia(&telemetry) != 0) {
+    fprintf(stderr, "no supported NVIDIA telemetry backend\n");
     return 3;
   }
-
   if (!isfinite(telemetry.usage) || telemetry.usage < 0.0 ||
       telemetry.usage > 100.0)
     return 4;
 
-  printf("backend\t%s\n", telemetry.backend);
+  printf("backend\tnvidia\n");
   printf("usage\t%.2f\n", telemetry.usage);
   if (telemetry.has_temperature)
     printf("temperature\t%.2f\n", telemetry.temperature);

--- a/setup-gpu-helper.sh
+++ b/setup-gpu-helper.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/bin/bash
+set -euo pipefail
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 target_dir=${XDG_DATA_HOME:-"$HOME/.local/share"}/ilyazar-btop
@@ -9,12 +9,4 @@ mkdir -p "$target_dir"
 cc -O2 -std=c11 -Wall -Wextra -Werror \
   "$script_dir/gpu-telemetry.c" -ldl -o "$target"
 
-needs_perfmon=false
-[ -d /sys/bus/event_source/devices/i915 ] && needs_perfmon=true
-
-if "$needs_perfmon"; then
-  sudo setcap cap_perfmon=ep "$target"
-fi
-
 printf 'installed %s\n' "$target"
-getcap "$target" 2>/dev/null || true

--- a/tests/test_gpu_fdinfo.sh
+++ b/tests/test_gpu_fdinfo.sh
@@ -29,18 +29,64 @@ write_fdinfo() {
   mv -T -- "$temporary" "$path"
 }
 
+assert_large_fd_set() {
+  local long_name large_root large_proc large_dri large_device sample pid output
+  local -a directories=()
+
+  printf -v long_name 'x%.0s' {1..180}
+  large_root=$temp_root/fd/$long_name
+  large_proc=$large_root/proc
+  large_dri=$large_root/dri
+  large_device=$large_dri/renderD128
+  sample=$large_root/sample-fdinfo
+
+  directories+=("$large_dri")
+  for pid in {100..155}; do
+    directories+=("$large_proc/$pid/fd" "$large_proc/$pid/fdinfo")
+  done
+  printf '%s\0' "${directories[@]}" | xargs -0 -r mkdir -p
+  : >"$large_device"
+  write_fdinfo "$sample" 7 0
+
+  for pid in {100..155}; do
+    ln -s "$large_device" "$large_proc/$pid/fd/5"
+    ln -s "$sample" "$large_proc/$pid/fdinfo/5"
+  done
+
+  if env -i PATH="$PATH" bash -c '
+      ulimit -s 512
+      printf -v PAD "%*s" 120000 ""
+      export PAD
+      /bin/true "$@" 2>/dev/null
+    ' _ "${directories[@]}"; then
+    return 1
+  else
+    [[ $? -eq 126 ]]
+  fi
+
+  output=$(
+    env -i PATH="$PATH" bash -c '
+      ulimit -s 512
+      printf -v PAD "%*s" 120000 ""
+      export PAD
+      BTOP_GPU_PROC_ROOT=$1 BTOP_GPU_DRI_ROOT=$2 bash "$3" 50
+    ' _ "$large_proc" "$large_dri" "$plugin_root/gpu-fdinfo.sh"
+  )
+  [[ $output == $'usage\t0.00' ]]
+}
+
 for descriptor in 5 6 7; do
   ln -s "$device" "$process_root/fd/$descriptor"
 done
-write_fdinfo "$process_root/fdinfo/5" 7 100000000
-write_fdinfo "$process_root/fdinfo/6" 7 100000000
-write_fdinfo "$process_root/fdinfo/7" 8 20000000
+write_fdinfo "$process_root/fdinfo/5" 7 0
+write_fdinfo "$process_root/fdinfo/6" 7 0
+write_fdinfo "$process_root/fdinfo/7" 8 0
 
 (
   sleep 0.10
-  write_fdinfo "$process_root/fdinfo/5" 7 200000000
-  write_fdinfo "$process_root/fdinfo/6" 7 200000000
-  write_fdinfo "$process_root/fdinfo/7" 8 30000000
+  write_fdinfo "$process_root/fdinfo/5" 7 100000000
+  write_fdinfo "$process_root/fdinfo/6" 7 100000000
+  write_fdinfo "$process_root/fdinfo/7" 8 10000000
 ) &
 updater=$!
 
@@ -51,6 +97,15 @@ wait "$updater"
 [[ $output == usage$'\t'* ]]
 usage=${output#*$'\t'}
 awk -v usage="$usage" 'BEGIN { exit !(usage >= 25 && usage <= 65) }'
+
+write_fdinfo "$process_root/fdinfo/5" 7 0
+write_fdinfo "$process_root/fdinfo/6" 7 0
+write_fdinfo "$process_root/fdinfo/7" 8 0
+output=$(BTOP_GPU_PROC_ROOT=$proc_root BTOP_GPU_DRI_ROOT=$dri_root \
+  bash "$plugin_root/gpu-fdinfo.sh" 50)
+[[ $output == $'usage\t0.00' ]]
+
+assert_large_fd_set
 
 if BTOP_GPU_PROC_ROOT=$temp_root/empty \
     BTOP_GPU_DRI_ROOT=$dri_root \

--- a/tests/test_gpu_fdinfo.sh
+++ b/tests/test_gpu_fdinfo.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+test_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+plugin_root=$(cd "$test_dir/.." && pwd)
+temp_root=$(mktemp -d)
+readonly plugin_root temp_root
+trap 'rm -rf -- "$temp_root"' EXIT
+
+proc_root=$temp_root/proc
+dri_root=$temp_root/dri
+process_root=$proc_root/123
+device=$dri_root/renderD128
+mkdir -p "$process_root/fd" "$process_root/fdinfo" "$dri_root"
+: >"$device"
+
+write_fdinfo() {
+  local path=$1
+  local client=$2
+  local render_ns=$3
+  local temporary=$path.tmp
+
+  printf '%s\n' \
+    $'drm-driver:\ti915' \
+    $'drm-client-id:\t'"$client" \
+    $'drm-pdev:\t0000:00:02.0' \
+    $'drm-engine-render:\t'"$render_ns"' ns' \
+    $'drm-engine-copy:\t0 ns' >"$temporary"
+  mv -T -- "$temporary" "$path"
+}
+
+for descriptor in 5 6 7; do
+  ln -s "$device" "$process_root/fd/$descriptor"
+done
+write_fdinfo "$process_root/fdinfo/5" 7 100000000
+write_fdinfo "$process_root/fdinfo/6" 7 100000000
+write_fdinfo "$process_root/fdinfo/7" 8 20000000
+
+(
+  sleep 0.10
+  write_fdinfo "$process_root/fdinfo/5" 7 200000000
+  write_fdinfo "$process_root/fdinfo/6" 7 200000000
+  write_fdinfo "$process_root/fdinfo/7" 8 30000000
+) &
+updater=$!
+
+output=$(BTOP_GPU_PROC_ROOT=$proc_root BTOP_GPU_DRI_ROOT=$dri_root \
+  bash "$plugin_root/gpu-fdinfo.sh" 200)
+wait "$updater"
+
+[[ $output == usage$'\t'* ]]
+usage=${output#*$'\t'}
+awk -v usage="$usage" 'BEGIN { exit !(usage >= 25 && usage <= 65) }'
+
+if BTOP_GPU_PROC_ROOT=$temp_root/empty \
+    BTOP_GPU_DRI_ROOT=$dri_root \
+    bash "$plugin_root/gpu-fdinfo.sh" 50; then
+  exit 1
+else
+  [[ $? -eq 3 ]]
+fi
+
+if bash "$plugin_root/gpu-fdinfo.sh" invalid; then
+  exit 1
+else
+  [[ $? -eq 2 ]]
+fi
+
+printf 'ok - gpu fdinfo sampling\n'

--- a/tests/test_tooltip_plain_text.sh
+++ b/tests/test_tooltip_plain_text.sh
@@ -29,9 +29,8 @@ tooltip_source() {
 source_text="$(tooltip_source)"
 [[ -n $source_text ]] || fail "could not extract the tooltip construction from BarWidget.qml"
 
-# `<unavailable>` is deliberate literal text and reads correctly under
-# PlainText; a real tag has a letter or slash straight after the bracket.
-if grep -Eq '<(/|[A-Za-z]+[ >])' <<<"${source_text//<unavailable>/}"; then
+# A real tag has a letter or slash straight after the opening bracket.
+if grep -Eq '<(/|[A-Za-z]+[ >])' <<<"$source_text"; then
   fail "tooltip construction emits HTML tags (the bar renders PlainText)"
 fi
 

--- a/tests/test_tooltip_plain_text.sh
+++ b/tests/test_tooltip_plain_text.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# The bar renders tooltips with `textFormat: Text.PlainText` (Omarchy's
+# Ui/Button.qml and plugins/bar/Bar.qml), so any HTML the widget puts in
+# `tooltipText` is shown to the user as literal tag text. Guard the tooltip
+# construction against markup and HTML entities creeping back in.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+readonly TEST_DIR PLUGIN_ROOT
+
+readonly WIDGET="$PLUGIN_ROOT/BarWidget.qml"
+
+fail() {
+  echo "not ok - $1" >&2
+  exit 1
+}
+
+# The tooltip property and the helper it calls, i.e. everything that ends up in
+# tooltipText. Stops at the next top-level property to keep unrelated QML out.
+tooltip_source() {
+  sed -n '/readonly property string tooltip:/,/^  readonly property var sortingChoices/p' "$WIDGET"
+  sed -n '/^  function alignedTooltip(/,/^  }/p' "$WIDGET"
+  sed -n '/^  readonly property string gpuTemperatureText:/,/^  readonly property string tooltip:/p' "$WIDGET"
+}
+
+source_text="$(tooltip_source)"
+[[ -n $source_text ]] || fail "could not extract the tooltip construction from BarWidget.qml"
+
+# `<unavailable>` is deliberate literal text and reads correctly under
+# PlainText; a real tag has a letter or slash straight after the bracket.
+if grep -Eq '<(/|[A-Za-z]+[ >])' <<<"${source_text//<unavailable>/}"; then
+  fail "tooltip construction emits HTML tags (the bar renders PlainText)"
+fi
+
+if grep -q '&amp;\|&lt;\|&gt;' <<<"$source_text"; then
+  fail "tooltip construction escapes HTML entities (the bar renders PlainText)"
+fi
+
+# The rich-text helper this replaced must not come back.
+if grep -q 'styledTooltip' "$WIDGET"; then
+  fail "styledTooltip is back in BarWidget.qml"
+fi
+
+# tooltipText must be fed the plain aligned text directly.
+if ! grep -q 'readonly property string tooltip: alignedTooltip(' "$WIDGET"; then
+  fail "tooltip is no longer built straight from alignedTooltip"
+fi
+
+if ! grep -q 'tooltipText: root.tooltip' "$WIDGET"; then
+  fail "the bar button no longer takes its tooltip from root.tooltip"
+fi
+
+echo "ok - tooltip stays plain text"


### PR DESCRIPTION
## What

Omarchy now renders bar tooltips as plain text. The plugin wrapped an
unavailable GPU temperature in `<pre>` and `<font>` markup, so the shared
tooltip exposed those tags after omacom/omarchy#8397.

Keep @gw7523's plain-text fix and regression test, then make the remaining
fallback plain text too.

On Intel, read GPU engine time from per-client DRM fdinfo instead of requiring
a locally built helper with `cap_perfmon`. NVIDIA continues to use the narrow
NVML helper, while AMD continues to use DRM sysfs.

## Why

The tooltip must honor the host's plain-text contract.

Intel `i915` already exposes unprivileged per-client engine counters. Using
them makes GPU usage work immediately after plugin installation on systems
where system-wide performance counters are restricted.

The sampler discovers descriptors once per sample, preserves idle counters,
deduplicates clients, handles large descriptor sets, and centers elapsed time
across both snapshots.

GPU temperature still reports `unavailable` when the driver exposes no
temperature sensor.

## Testing

- reproduced the literal tooltip tags before the fix
- verified the compact three-row tooltip on Omarchy
- passed the tooltip, fdinfo, and runtime lifecycle shell tests
- passed the QML unit suite and `qmllint`
- compiled the NVML helper with warnings as errors
- passed `omarchy plugin validate` and the publishing preflight
- reduced five 50 ms samples from about 386 ms to 144 ms on Intel