### PR TITLE
feat: read poll intervals and left click from settings.toml

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -1,9 +1,11 @@
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
+import Quickshell.Io
 import qs.Commons
 import qs.Ui
 import "lib/shortcuts" as Shortcuts
+import "lib/Settings.js" as Settings
 import "lib/UpdateInterval.js" as UpdateInterval
 import "lib/BtopHumanizer.js" as BtopHumanizer
 
@@ -22,6 +24,7 @@ Panel {
     property bool updateEditing: false
     property string pendingLaunch: ""
     property bool configSynced: false
+    property string leftClick: Settings.defaults.leftClick
 
     readonly property var activity: bar && bar.shell ? bar.shell.serviceFor(moduleName) : null
     readonly property color foreground: bar ? bar.barForeground : Color.foreground
@@ -33,6 +36,7 @@ Panel {
     readonly property string customIconPath: String(setting("customIconPath", ""))
     readonly property string customIconUrl: resolveIconPath(customIconPath)
     readonly property string keybindingsScript: localPath(Qt.resolvedUrl("helpers/open-keybindings.sh"))
+    readonly property string toggleScript: localPath(Qt.resolvedUrl("helpers/toggle-btop.sh"))
     readonly property string windowMode: String(setting("windowMode", "Floating"))
     readonly property int updateMs: intSetting("updateMs", 2000, UpdateInterval.minimum, UpdateInterval.maximum)
     readonly property var updateDraftValue: UpdateInterval.parse(updateDraft)
@@ -71,6 +75,18 @@ Panel {
     Shortcuts.HyprlandBinding {
         id: activityBinding
         actionDescription: "Activity"
+    }
+
+    property FileView settingsFile: FileView {
+        path: root.localPath(Qt.resolvedUrl("settings.toml"))
+        printErrors: false
+        onLoaded: root.applySettings(text())
+    }
+
+    function applySettings(text) {
+        var settings = Settings.parse(text);
+        UpdateInterval.usePresets(settings.pollIntervals);
+        leftClick = settings.leftClick;
     }
 
     function intSetting(name, fallback, minimum, maximum) {
@@ -175,12 +191,18 @@ Panel {
         pendingLaunch = "";
         if (action === "help")
             execBtopHelp();
+        else if (action === "toggle")
+            execToggle();
         else
             execBtop();
     }
 
     function execBtop() {
         Quickshell.execDetached(["omarchy-launch-or-focus-tui", "--app-id=" + btopAppId, "btop", "--config", activity.configPath]);
+    }
+
+    function execToggle() {
+        Quickshell.execDetached(["bash", toggleScript, btopAppId, activity.configPath]);
     }
 
     function execBtopHelp() {
@@ -191,7 +213,7 @@ Panel {
 
     function launchBtop() {
         close();
-        launchWhenConfigReady("btop");
+        launchWhenConfigReady(leftClick === "toggle" ? "toggle" : "btop");
     }
 
     function launchBtopHelp() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Notable changes to btop Activity are documented here.
 
+## Unreleased
+
+- Read defaults from a shipped `settings.toml`: `poll_intervals` sets the
+  interval ladder the Update interval arrows step through, and `left_click`
+  chooses whether a left click opens btop or toggles it (@gw7523).
+- Add `helpers/toggle-btop.sh`, which closes the plugin's btop window when one
+  is open and launches btop otherwise. It backs `left_click = "toggle"` and can
+  be bound directly, so one key both opens and closes btop (@gw7523).
+
 ## 0.2.2 - 2026-09-05
 
 - Replace the compiled GPU helper with kernel readings and optional native

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ The plugin keeps a short list of useful controls before opening btop:
 | Process tree    | on or off                                |
 
 For the update interval, press Enter or click the value to edit it. Left/Right
-(or `h`/`l`) change it by 1 ms. Up/Down (or `k`/`j`) move through 250, 500,
-1000, 2000, and 5000 ms while still letting you type any value in btop's full
-range. From a custom value, they jump to the next preset above or below it and
-wrap around at the ends.
+(or `h`/`l`) change it by 1 ms. Up/Down (or `k`/`j`) move through the presets
+in [`settings.toml`](#settingstoml) while still letting you type any value in
+btop's full range. From a custom value, they jump to the next preset above or
+below it and wrap around at the ends.
 
 Edit `~/.config/hypr/bindings.lua` directly, or select **Keybindings** in the
 plugin settings to open it. The button prefers Neovim, jumping to an existing
@@ -93,6 +93,33 @@ Plugin choices are stored in Omarchy's `shell.json` and survive shell restarts.
 Under **Appearance**, choose whether btop opens tiled or floating. The setting
 applies to both left-click and Help. Floating is the default and restores
 Omarchy's centered 875 x 600 window size when selected.
+
+### settings.toml
+
+Two defaults live in the plugin's `settings.toml` rather than in the popup:
+
+| Key              | Default                      | Meaning                            |
+| ---------------- | ---------------------------- | ---------------------------------- |
+| `poll_intervals` | `[250, 500, 1000, 2000, 5000]` | ladder the interval arrows step through |
+| `left_click`     | `"open"`                     | `"open"` or `"toggle"`             |
+
+Values outside btop's 100 ms to one day range, and repeated ones, are dropped;
+an unreadable or empty file leaves the defaults above in place. Apply an edit
+with `omarchy restart shell`.
+
+With `left_click = "toggle"`, clicking the widget while btop is open closes the
+window instead of focusing it. The same script can be bound directly, so one
+key both opens and closes btop:
+
+```lua
+hl.unbind("SUPER + CTRL + T")
+o.bind("SUPER + CTRL + T", "Activity", os.getenv("HOME")
+  .. "/.config/omarchy/plugins/ilyazar.btop/helpers/toggle-btop.sh")
+```
+
+Invoked bare like that, the script takes the window mode from `shell.json`,
+closes any btop window the plugin opened in either mode, and otherwise launches
+btop with the plugin's runtime config when one exists.
 
 ## Optional hardware setup
 

--- a/helpers/toggle-btop.sh
+++ b/helpers/toggle-btop.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Close the plugin's btop window when one is open, otherwise launch btop.
+#
+# The bar widget runs this with both arguments when settings.toml sets
+# `left_click = "toggle"`. Bound bare, it makes one key open and close btop:
+#
+#   hl.unbind("SUPER + CTRL + T")
+#   o.bind("SUPER + CTRL + T", "Activity", os.getenv("HOME")
+#     .. "/.config/omarchy/plugins/ilyazar.btop/helpers/toggle-btop.sh")
+
+set -euo pipefail
+
+app_id="${1:-}"
+config="${2:-}"
+
+if [[ -z $app_id ]]; then
+  # Bare invocation: follow the widget's own window mode and runtime config.
+  mode=$(jq -r '.. | objects | select(.id? == "ilyazar.btop") | .windowMode // empty' \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/shell.json" 2>/dev/null | head -n 1 || true)
+  app_id=org.omarchy.btop
+  [[ ${mode:-} == Tiled ]] && app_id=org.omarchy.btop_tiled
+  runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ilyazar-btop.conf"
+  if [[ -f $runtime ]]; then config=$runtime; fi
+fi
+
+# Close windows from either mode, so switching Floating/Tiled while btop is
+# open cannot strand the window opened under the previous mode.
+addresses=$(hyprctl clients -j 2>/dev/null | jq -r '.[]
+  | select(.class == "org.omarchy.btop" or .class == "org.omarchy.btop_tiled")
+  | .address' || true)
+
+if [[ -n $addresses ]]; then
+  while read -r address; do
+    # Omarchy's Hyprland speaks Lua dispatchers; closewindow covers a stock one.
+    hyprctl dispatch "hl.dsp.window.close({ window = \"address:$address\" })" \
+      >/dev/null 2>&1 ||
+      hyprctl dispatch closewindow "address:$address" >/dev/null 2>&1 || true
+  done <<<"$addresses"
+  exit 0
+fi
+
+launch=(omarchy-launch-or-focus-tui "--app-id=$app_id" btop)
+[[ -n $config ]] && launch+=(--config "$config")
+exec "${launch[@]}"

--- a/lib/Settings.js
+++ b/lib/Settings.js
@@ -1,0 +1,46 @@
+.pragma library
+
+// Minimal reader for the shipped settings.toml: top-level `key = value` pairs
+// whose value is a quoted string or an array of integers. Anything missing or
+// unparsable keeps the default below.
+
+var defaults = { leftClick: "open" }
+
+function stripComment(line) {
+  var quoted = false
+  for (var i = 0; i < line.length; i++) {
+    if (line[i] === "\"") quoted = !quoted
+    else if (line[i] === "#" && !quoted) return line.substring(0, i)
+  }
+  return line
+}
+
+function intList(value) {
+  var body = /^\[(.*)\]$/.exec(value)
+  if (!body) return null
+  var items = body[1].split(",").map(function (item) { return item.trim() })
+  if (items.length && items[items.length - 1] === "") items.pop()
+  var numbers = []
+  for (var i = 0; i < items.length; i++) {
+    if (!/^[0-9]+$/.test(items[i])) return null
+    numbers.push(Number(items[i]))
+  }
+  return numbers.length ? numbers : null
+}
+
+function parse(text) {
+  var settings = { pollIntervals: null, leftClick: defaults.leftClick }
+  var lines = String(text === null || text === undefined ? "" : text).split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var pair = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$/.exec(
+      stripComment(lines[i]))
+    if (!pair) continue
+    if (pair[1] === "poll_intervals") settings.pollIntervals = intList(pair[2])
+    else if (pair[1] === "left_click") {
+      var word = /^"([a-z]*)"$/.exec(pair[2])
+      if (word && (word[1] === "open" || word[1] === "toggle"))
+        settings.leftClick = word[1]
+    }
+  }
+  return settings
+}

--- a/lib/UpdateInterval.js
+++ b/lib/UpdateInterval.js
@@ -4,6 +4,18 @@ var minimum = 100
 var maximum = 86400000
 var presets = [250, 500, 1000, 2000, 5000]
 
+// Replace the ladder with the values from settings.toml, dropping any that
+// are out of range or repeated. An empty result keeps the defaults above.
+function usePresets(values) {
+  var accepted = []
+  for (var i = 0; i < (values || []).length; i++) {
+    var value = parse(values[i])
+    if (value !== null && accepted.indexOf(value) < 0) accepted.push(value)
+  }
+  if (accepted.length)
+    presets = accepted.sort(function (a, b) { return a - b })
+}
+
 function parse(value) {
   var text = String(value === null || value === undefined ? "" : value).trim()
   if (!/^[0-9]+$/.test(text)) return null

--- a/settings.toml
+++ b/settings.toml
@@ -1,0 +1,11 @@
+# btop Activity defaults. Edit and restart the shell to apply:
+#
+#   omarchy restart shell
+
+# Interval ladder, in milliseconds, that the Update interval arrows step
+# through. Any whole number from 100 ms to one day can still be typed.
+poll_intervals = [250, 500, 1000, 2000, 5000]
+
+# What a left click on the widget does. "open" launches or focuses btop;
+# "toggle" also closes the window when btop is already open.
+left_click = "open"

--- a/tests/test_toggle_btop.sh
+++ b/tests/test_toggle_btop.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$TEST_DIR/.." && pwd)"
+TEMP_ROOT="$(mktemp -d)"
+readonly TEST_DIR PLUGIN_ROOT TEMP_ROOT
+trap 'rm -rf -- "$TEMP_ROOT"' EXIT
+
+readonly MOCK_BIN="$TEMP_ROOT/bin"
+readonly LOG="$TEMP_ROOT/calls.log"
+readonly CLIENTS="$TEMP_ROOT/clients.json"
+readonly RUNTIME_CONFIG="$TEMP_ROOT/runtime/ilyazar-btop.conf"
+
+mkdir -p "$MOCK_BIN" "$TEMP_ROOT/runtime" "$TEMP_ROOT/config/omarchy"
+
+cat >"$MOCK_BIN/hyprctl" <<MOCK
+#!/bin/bash
+[[ \$1 == clients ]] && exec cat "$CLIENTS"
+shift
+printf 'close %s\n' "\$*" >>"$LOG"
+MOCK
+
+cat >"$MOCK_BIN/omarchy-launch-or-focus-tui" <<MOCK
+#!/bin/bash
+printf 'launch %s\n' "\$*" >>"$LOG"
+MOCK
+
+chmod 0755 "$MOCK_BIN/hyprctl" "$MOCK_BIN/omarchy-launch-or-focus-tui"
+
+run_toggle() {
+  : >"$LOG"
+  env PATH="$MOCK_BIN:$PATH" HOME="$TEMP_ROOT" \
+    XDG_CONFIG_HOME="$TEMP_ROOT/config" XDG_RUNTIME_DIR="$TEMP_ROOT/runtime" \
+    bash "$PLUGIN_ROOT/helpers/toggle-btop.sh" "$@"
+}
+
+# An open window is closed and nothing new is launched. Windows from either
+# window mode count, so switching modes cannot strand one.
+for class in org.omarchy.btop org.omarchy.btop_tiled; do
+  printf '[{"class": "%s", "address": "0xabc"}]' "$class" >"$CLIENTS"
+  run_toggle org.omarchy.btop "$RUNTIME_CONFIG"
+  grep -Fq 'close hl.dsp.window.close({ window = "address:0xabc" })' "$LOG"
+  ! grep -q '^launch' "$LOG"
+done
+
+# No window: launch with the arguments the widget passes.
+printf '[]' >"$CLIENTS"
+run_toggle org.omarchy.btop "$RUNTIME_CONFIG"
+grep -Fq "launch --app-id=org.omarchy.btop btop --config $RUNTIME_CONFIG" "$LOG"
+
+# Bare invocation (a keybinding): window mode comes from shell.json and the
+# runtime config is used when it exists.
+printf '{"bar":{"layout":{"right":[{"id":"ilyazar.btop","windowMode":"Tiled"}]}}}' \
+  >"$TEMP_ROOT/config/omarchy/shell.json"
+: >"$RUNTIME_CONFIG"
+run_toggle
+grep -Fq "launch --app-id=org.omarchy.btop_tiled btop --config $RUNTIME_CONFIG" "$LOG"
+
+# Bare invocation without either falls back to a plain floating launch.
+rm "$RUNTIME_CONFIG" "$TEMP_ROOT/config/omarchy/shell.json"
+run_toggle
+grep -Fqx 'launch --app-id=org.omarchy.btop btop' "$LOG"
+
+printf 'ok - toggle btop\n'

--- a/tests/tst_settings.qml
+++ b/tests/tst_settings.qml
@@ -1,0 +1,52 @@
+import QtQuick
+import QtTest
+import "../lib/Settings.js" as Settings
+
+TestCase {
+  name: "Settings"
+
+  readonly property string shipped: '# comment\npoll_intervals = [250, 500, 1000, 2000, 5000]\nleft_click = "open"\n'
+
+  function test_shipped_file() {
+    var settings = Settings.parse(shipped)
+    compare(settings.pollIntervals, [250, 500, 1000, 2000, 5000])
+    compare(settings.leftClick, "open")
+  }
+
+  function test_left_click_data() {
+    return [
+      { tag: "toggle", input: 'left_click = "toggle"', expected: "toggle" },
+      { tag: "trailing comment", input: 'left_click = "toggle" # why', expected: "toggle" },
+      { tag: "commented out", input: '# left_click = "toggle"', expected: "open" },
+      { tag: "unknown value", input: 'left_click = "flip"', expected: "open" },
+      { tag: "unquoted", input: 'left_click = toggle', expected: "open" },
+      { tag: "hash inside string", input: 'left_click = "toggle"', expected: "toggle" },
+      { tag: "missing", input: '', expected: "open" }
+    ]
+  }
+
+  function test_left_click(data) {
+    compare(Settings.parse(data.input).leftClick, data.expected)
+  }
+
+  function test_poll_intervals_data() {
+    return [
+      { tag: "single", input: "poll_intervals = [1000]", expected: [1000] },
+      { tag: "trailing comma", input: "poll_intervals = [250, 500,]", expected: [250, 500] },
+      { tag: "spaced", input: "poll_intervals=[ 250 ,500 ]", expected: [250, 500] },
+      { tag: "empty list", input: "poll_intervals = []", expected: null },
+      { tag: "non-integer", input: "poll_intervals = [250, fast]", expected: null },
+      { tag: "not a list", input: "poll_intervals = 250", expected: null },
+      { tag: "missing", input: "", expected: null }
+    ]
+  }
+
+  function test_poll_intervals(data) {
+    compare(Settings.parse(data.input).pollIntervals, data.expected)
+  }
+
+  function test_absent_file() {
+    compare(Settings.parse(null).pollIntervals, null)
+    compare(Settings.parse(null).leftClick, "open")
+  }
+}

--- a/tests/tst_update_interval.qml
+++ b/tests/tst_update_interval.qml
@@ -81,4 +81,20 @@ TestCase {
   function test_ladder(data) {
     compare(UpdateInterval.ladder(data.input, data.direction), data.expected)
   }
+
+  // Runs last: usePresets replaces shared library state, so restore the
+  // shipped ladder before leaving.
+  function test_use_presets() {
+    UpdateInterval.usePresets([2000, 250, 250, 99, 500])
+    compare(UpdateInterval.presets, [250, 500, 2000])
+    compare(UpdateInterval.ladder(300, 1), 500)
+
+    UpdateInterval.usePresets([])
+    compare(UpdateInterval.presets, [250, 500, 2000])
+    UpdateInterval.usePresets(null)
+    compare(UpdateInterval.presets, [250, 500, 2000])
+
+    UpdateInterval.usePresets([250, 500, 1000, 2000, 5000])
+    compare(UpdateInterval.presets, [250, 500, 1000, 2000, 5000])
+  }
 }


### PR DESCRIPTION
Replaces #32, rebuilt on `0.2.2` rather than rebased — the old branch predates
the `helpers/` move and the telemetry work, so a rebase would have been mostly
conflict resolution. Closing #32 in favour of this.

This is your ask from #32: a `settings.toml` that ships with the plugin, holding
the polling ladder as an array plus the toggle setting, and a leaner
implementation than the original.

### settings.toml

```toml
poll_intervals = [250, 500, 1000, 2000, 5000]
left_click = "open"
```

`poll_intervals` is the ladder the Update interval arrows step through — it was
hardcoded in `lib/UpdateInterval.js`. `UpdateInterval.usePresets()` drops values
outside btop's 100 ms–1 day range and repeats, and keeps its own ladder if
nothing usable is left, so the arrows always have something to step through.

`left_click` chooses whether a left click opens btop or toggles it.

`lib/Settings.js` (46 lines) reads only what the file needs — top-level
`key = value` where the value is a quoted string or an array of integers.
Anything missing or unparsable falls back to the default, so a hand-edited file
can't break the widget. It's deliberately not a general TOML parser; if you'd
rather it grew tables or more types for your other plugins, say so and I'll
extend it.

### Leaner than #32

- `manifest.json` is **untouched** — no schema entry, no defaults key, and no
  "Left click" MenuRow in the popup, since the setting now lives in the TOML.
- `helpers/toggle-btop.sh` is 45 lines, down from 114: positional args instead
  of flag parsing, and the SIGTERM fallback dropped.
- `BarWidget.qml` is +24 lines: a `FileView`, `applySettings()`, and
  `execToggle()`.

Net runtime code is slightly smaller than #32 even with the config file added.

### toggle-btop.sh

Closes windows from either window mode, so switching Floating/Tiled while btop
is open can't strand the old window. Prefers Omarchy's Lua close dispatcher with
`closewindow` as the fallback. Bound bare it takes the window mode from
`shell.json` and uses the runtime config only when it already exists — a missing
config launches plain, like the stock binding, instead of creating one:

```lua
hl.unbind("SUPER + CTRL + T")
o.bind("SUPER + CTRL + T", "Activity", os.getenv("HOME")
  .. "/.config/omarchy/plugins/ilyazar.btop/helpers/toggle-btop.sh")
```

### One thing worth your call

`settings.toml` ships inside the plugin's git checkout, so a user edit will
conflict on `omarchy plugin update`. I did not add a second user-config path
under `~/.config` — that cuts against "leanest", and it's your convention to
set. Happy to layer one in if you want it.

### Tests

- `tests/tst_settings.qml` — 18 cases over the parser
- `tests/tst_update_interval.qml` — a `usePresets` case; restores the shipped
  ladder afterwards since `.pragma library` state is shared
- `tests/test_toggle_btop.sh` — mocked `hyprctl` and launcher

All pass here under `qmltestrunner`, along with the existing
`test_runtime_config_cleanup.sh`.